### PR TITLE
Fix partners section background color inconsistency

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -634,3 +634,10 @@ a.bg-\[#ff7a2f\]:hover, a.bg-\[#ff7a2f\]:active {
 .animate-in-right { animation: slideInRight 0.45s ease both; }
 @keyframes slideInLeft { from { transform: translateX(-24px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
 @keyframes slideInRight { from { transform: translateX(24px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+
+/* Force light theme regardless of device color scheme */
+html.force-light { --background: #ffffff; --foreground: #171717; }
+@media (prefers-color-scheme: dark) { html.force-light { --background: #ffffff; --foreground: #171717; } }
+
+/* Ensure partners section is always light */
+.partners-section { background: #ffffff; }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className="force-light">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >


### PR DESCRIPTION
## Purpose
The user identified an inconsistency where the partners section displayed with a white background on desktop but had a black background on mobile devices. They requested a comprehensive review and fix to ensure consistent styling across all devices and sections.

## Code changes
- Added `force-light` class to the HTML element in layout.tsx to enforce light theme globally
- Created CSS rules to override dark mode preferences and maintain light theme variables
- Added specific styling for `.partners-section` to ensure it always has a white background (#ffffff)
- Implemented media query override to prevent dark mode from affecting the forced light theme

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e3b336d7481a48078a7b4de3b8878d57/orbit-sanctuary)

👀 [Preview Link](https://e3b336d7481a48078a7b4de3b8878d57-orbit-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e3b336d7481a48078a7b4de3b8878d57</projectId>-->
<!--<branchName>orbit-sanctuary</branchName>-->