### PR TITLE
Fix Next.js linting errors and horizontal scroll issue

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,7 +50,7 @@
 .hero-stat .num { font-weight:800; color:#0f172a; font-size:1.5rem; }
 .hero-stat .label { font-size:0.875rem; color:#64748b; }
 
-.hero-image-frame { border-radius: 14px; overflow: hidden; box-shadow: 0 28px 60px rgba(2,6,23,0.08); display:flex; align-items:flex-end; min-height: 320px; align-self: stretch; }
+.hero-image-frame { border-radius: 14px; overflow: hidden; box-shadow: 0 28px 60px rgba(2,6,23,0.08); display:flex; align-items:flex-end; min-height: 320px; align-self: stretch; position: relative; }
 .hero-image-frame img { display:block; width:100%; height:100%; object-fit:cover; object-position: bottom center; }
 
 
@@ -424,7 +424,7 @@ html.force-light { --background: #f7fafc; --foreground: #0f172a; }
 .advertising-visual-frame::before {
   content: "";
   position: absolute;
-  inset: 10% -14% auto 60%;
+  inset: 10% 0 auto 60%;
   height: 4px;
   background: #2563eb;
   border-radius: 999px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Playfair_Display } from "next/font/google";
 import NextImage from "next/image";
+import Link from "next/link";
 import ScrollProgress from "../components/ScrollProgress";
 import "./globals.css";
 
@@ -37,13 +38,13 @@ export default function RootLayout({
         <header className="site-header sticky top-0 z-50">
           <ScrollProgress />
           <div className="max-w-[1200px] mx-auto px-2 sm:px-4 h-14 flex items-center justify-between">
-            <a href="/" className="brand-link flex items-center gap-3">
+            <Link href="/" className="brand-link flex items-center gap-3">
               <span className="brand-logo" aria-hidden="true">
                 <NextImage src="/logo.jpg" alt="Wolves logo" width={36} height={36} className="rounded-mark-img" />
               </span>
 
               <span className={`${playfair.variable} brand-name`} style={{background: 'linear-gradient(90deg,#2563eb,#7cc0ff)', WebkitBackgroundClip: 'text', color: 'transparent'}}>Wolves</span>
-            </a>
+            </Link>
             <nav className="header-nav hidden sm:flex items-center gap-4">
               <a href="#results" className="nav-link">Results</a>
               <a href="#pricing" className="nav-link">Pricing</a>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,7 +50,7 @@ export default function Home() {
             </div>
 
             <div className="hero-image-frame">
-              <img src="/banner.png" alt="Banner person" />
+              <NextImage src="/banner.png" alt="Banner person" fill priority sizes="(min-width: 1024px) 420px, (min-width: 768px) 50vw, 100vw" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Purpose

Fix two Next.js linting issues identified by ESLint:
1. Replace `<a>` element with Next.js `<Link>` component for internal navigation
2. Replace `<img>` element with Next.js `<Image>` component for optimized image loading

Additionally, resolve horizontal scrolling issue by adjusting CSS positioning and overflow properties.

## Code changes

- **layout.tsx**: Replace `<a href="/">` with `<Link href="/">` for the brand logo link and add required import
- **page.tsx**: Replace `<img>` with `<NextImage>` component with proper `fill`, `priority`, and `sizes` props for the hero banner
- **globals.css**: 
  - Add `position: relative` to `.hero-image-frame` to support the `fill` prop
  - Fix horizontal overflow by changing `.advertising-visual-frame::before` inset from `-14%` to `0`

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b3613b4254fe4e74a0900ef86f95779f/vibe-realm)

👀 [Preview Link](https://b3613b4254fe4e74a0900ef86f95779f-vibe-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b3613b4254fe4e74a0900ef86f95779f</projectId>-->
<!--<branchName>vibe-realm</branchName>-->