### PR TITLE
Fix media height, add gradient styling, reduce font sizes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -115,7 +115,13 @@ html.force-light { --background: #f7fafc; --foreground: #0f172a; }
 .zig-row.zig-left .zig-media { order: 1; }
 
 /* Ensure media panels never cause horizontal overflow */
-.zig-media { overflow: hidden; }
+.zig-media {
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px; /* ensure media blocks have enough height so logos and visuals are not clipped */
+}
 @media (max-width: 768px) { .zig-row { grid-template-columns: 1fr; } .zig-row .zig-media, .zig-row .zig-copy { order: unset; } }
 
 /* PRICING - featured card */
@@ -134,7 +140,16 @@ html.force-light { --background: #f7fafc; --foreground: #0f172a; }
 .testimonial-masonry-card .testimonial-content { padding-top: 0.75rem; }
 
 /* Results / Stats section */
-.results-section { background: transparent; }
+.results-section {
+  /* gradient background with a bold gradient border */
+  background: linear-gradient(135deg, rgba(250,250,255,1), rgba(236,245,255,1));
+  padding: 2rem 0;
+  border-radius: 16px;
+  border: 6px solid;
+  border-image: linear-gradient(90deg, #7c3aed, #2563eb) 1;
+  box-shadow: 0 30px 60px rgba(37,99,235,0.06);
+  margin: 1rem 0;
+}
 .results-grid { display: grid; grid-template-columns: 1fr; gap: 1rem; margin-top: 1.5rem; }
 @media (min-width: 768px) { .results-grid { grid-template-columns: repeat(3, 1fr); max-width: 960px; margin: 1.5rem auto 0; } }
 .results-card { background: linear-gradient(180deg, #ffffff, #f8fafc); border-radius: 12px; padding: 1.25rem; box-shadow: 0 18px 40px rgba(15,23,42,0.06); border: 1px solid rgba(15,23,42,0.04); display:flex; flex-direction:column; align-items:center; gap:0.75rem; }
@@ -230,7 +245,10 @@ html.force-light { --background: #f7fafc; --foreground: #0f172a; }
   position: relative;
   width: 100%;
   max-width: 100%;
-  min-height: 88px; /* reserve height for logos so absolute track doesn't hide (matches logo size + padding) */
+  min-height: 120px; /* reserve height for logos so absolute track doesn't hide (matches logo size + padding) */
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* absolutely position the track so it doesn't affect layout width, and center it vertically */
@@ -773,8 +791,8 @@ html.force-light { --background: #f7fafc; --foreground: #0f172a; }
 .country-card { display:flex; flex-direction:column; align-items:center; text-align:center; border-radius: 12px; padding: 1rem; background: linear-gradient(180deg,#ffffff,#f1f7ff); box-shadow: 0 16px 36px rgba(2,6,23,0.06); gap:0.5rem; min-width:0; }
 .country-card > * { min-width: 0; }
 .country-flag { width: 88px; height: 88px; border-radius: 999px; object-fit:cover; border: 3px solid rgba(37,99,235,0.08); }
-.country-card .country-name { font-weight:700; color:#0f172a; overflow-wrap: anywhere; word-break: break-word; text-align: center; max-width: 100%; }
-.country-card .country-email { color:#2563eb; font-weight:700; display:block; max-width:100%; overflow-wrap:anywhere; word-break:break-word; white-space:normal; }
+.country-card .country-name { font-weight:700; color:#0f172a; overflow-wrap: anywhere; word-break: break-word; text-align: center; max-width: 100%; font-size: 0.95rem; }
+.country-card .country-email { color:#2563eb; font-weight:700; display:block; max-width:100%; overflow-wrap:anywhere; word-break:break-word; white-space:normal; font-size: 0.825rem; font-weight:600; }
 .country-card .country-cta { margin-top:8px; padding:0.45rem 0.75rem; border-radius:999px; background: linear-gradient(90deg,#2563eb,#7cc0ff); color:white; font-weight:700; display:inline-block; }
 .country-card:hover { transform: translateY(-6px); box-shadow: 0 20px 40px rgba(15,23,42,0.06); }
 
@@ -793,6 +811,24 @@ html.force-light { --background: #f7fafc; --foreground: #0f172a; }
 .badge-contact-sub { color: #475569; margin-top: 0.5rem; }
 .badge-contact-cta { padding: 0.8rem 1.25rem; border-radius: 10px; background: linear-gradient(90deg,#7c3aed,#2563eb); color:white; font-weight:800; text-decoration:none; box-shadow: 0 18px 38px rgba(37,99,235,0.12); }
 .badge-contact-visual img { width: 96px; height:96px; }
+
+/* Make badge/contact section responsive on small screens */
+@media (max-width: 640px) {
+  .badge-contact-inner {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 1rem;
+    gap: 0.75rem;
+  }
+
+  .badge-contact-visual { width: 96px; flex: 0 0 auto; }
+  .badge-contact-visual img { width: 80px; height: 80px; }
+  .badge-contact-copy { padding: 0; }
+  .badge-contact-title { font-size: 1.15rem; }
+  .badge-contact-sub { font-size: 0.95rem; }
+  .badge-contact-cta { width: 100%; text-align: center; }
+}
 
 /* Footer */
 .site-footer { background: linear-gradient(180deg,#071124,#0f172a); color: rgba(255,255,255,0.95); padding: 2.25rem 0; border-top: 1px solid rgba(255,255,255,0.04); }


### PR DESCRIPTION
## Purpose
The user requested several UI improvements to fix layout issues and enhance visual styling:
- Fix missing height in media sections causing logo clipping
- Add attractive gradient background and border styling to the results/stats section
- Reduce font sizes for country and email text in media cards
- Make the badge/contact section responsive on mobile devices

## Code changes
- **Media sections**: Added `min-height: 120px` with flexbox centering to prevent logo clipping in `.zig-media` and logo container
- **Results section**: Applied gradient background (`rgba(250,250,255,1)` to `rgba(236,245,255,1)`), bold gradient border (`#7c3aed` to `#2563eb`), rounded corners, and subtle shadow
- **Typography**: Reduced font sizes for country names (0.95rem) and emails (0.825rem) in country cards
- **Mobile responsiveness**: Added responsive styles for badge/contact section with column layout, centered alignment, and adjusted sizing for screens under 640px

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 16`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1c6615fa0f724047a95a680a00d19cc0/glow-lab)

👀 [Preview Link](https://1c6615fa0f724047a95a680a00d19cc0-glow-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1c6615fa0f724047a95a680a00d19cc0</projectId>-->
<!--<branchName>glow-lab</branchName>-->